### PR TITLE
pin the version of ol to 20.0.0.6 in devfile

### DIFF
--- a/dev/devfile.yaml
+++ b/dev/devfile.yaml
@@ -47,7 +47,7 @@ commands:
     actions:
       - workdir: /projects/user-app
         type: exec
-        command: mvn -DhotTests=true liberty:dev
+        command: mvn -Dliberty.runtime.version=20.0.0.6 -DhotTests=true liberty:dev
         component: devruntime
     attributes:
         restart: "false"


### PR DESCRIPTION
the custom stack image contains an install of ol 20.0.0.6 - the devfile should adhere to that level in its liberty:dev mvn call. add a command line arg to specify the ol level targeted.