### PR TITLE
Add liberty.runtime.version to build cmd as well

### DIFF
--- a/dev/devfile.yaml
+++ b/dev/devfile.yaml
@@ -38,7 +38,7 @@ commands:
                                                                elif [[ -d /projects/target/liberty/wlp && ! -e /projects/.liberty-mv ]];
                                                                  then echo "STACK WARNING - LIBERTY RUNTIME WAS LOADED FROM HOST";
                                                                fi
-                                                            && mvn package
+                                                            && mvn -Dliberty.runtime.version=20.0.0.10 package
                                                             && touch ./.disable-bld-cmd;
                    fi
       workingDir: /projects

--- a/dev/devfile.yaml
+++ b/dev/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.0.0
 metadata:
   name: java-openliberty
-  version: 0.2.5
+  version: 0.2.6
   description: Java application stack using Open Liberty runtime
   alpha.build-dockerfile: "https://raw.githubusercontent.com/OpenLiberty/application-stack/master/dev/Dockerfile"
   alpha.deployment-manifest: "https://raw.githubusercontent.com/OpenLiberty/application-stack/master/dev/app-deploy.yaml"


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Problem here is that, if your pom.xml uses a liberty version other than the one the stack defines, your WLP install will get uninstalled in the run (dev mode) cmd; it'll be the wrong version.    

If we're going to override runtime version in devfile, do so for all commands. 