### PR TITLE
Use kernel-slim OL images for outer loop deployments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,12 +13,12 @@ BASE_OS_IMAGE="${BASE_OS_IMAGE:-adoptopenjdk/openjdk11-openj9:ubi}"
 #
 # Version of Open Liberty runtime to use within both inner and outer loops
 #
-OL_RUNTIME_VERSION="${OL_RUNTIME_VERSION:-20.0.0.10}"
+OL_RUNTIME_VERSION="${OL_RUNTIME_VERSION:-20.0.0.11}"
 
 #
 # The Open Liberty base image used in the final stage of the outer loop Dockerfile used to build your application image from
 #
-OL_UBI_IMAGE="${OL_UBI_IMAGE:-openliberty/open-liberty:20.0.0.10-kernel-java11-openj9-ubi}"
+OL_UBI_IMAGE="${OL_UBI_IMAGE:-openliberty/open-liberty:20.0.0.11-kernel-slim-java11-openj9-ubi}"
 
 #
 # The name and tag of the "stack image you will build.  This will used to create your inner loop development containers, and also as the base image for the first stage of your outer loop image build.
@@ -28,12 +28,12 @@ STACK_IMAGE="${STACK_IMAGE:-openliberty/application-stack:0.4}"
 #
 # URL at which your outer loop Dockerfile is hosted
 #
-DEVFILE_DOCKERFILE_LOC="${DEVFILE_DOCKERFILE_LOC:-https://github.com/OpenLiberty/application-stack/releases/download/outer-loop-0.4.0-rc/Dockerfile}"
+DEVFILE_DOCKERFILE_LOC="${DEVFILE_DOCKERFILE_LOC:-https://github.com/OpenLiberty/application-stack/releases/download/outer-loop-0.4.0-rc.1/Dockerfile}"
 
 #
 # URL at which your outer loop deploy YAML template is hosted
 #
-DEVFILE_DEPLOY_YAML_LOC="${DEVFILE_DEPLOY_YAML_LOC:-https://github.com/OpenLiberty/application-stack/releases/download/outer-loop-0.4.0-rc/app-deploy.yaml}"
+DEVFILE_DEPLOY_YAML_LOC="${DEVFILE_DEPLOY_YAML_LOC:-https://github.com/OpenLiberty/application-stack/releases/download/outer-loop-0.4.0-rc.1/app-deploy.yaml}"
 
 generate() {
     # Base customization.

--- a/stackimage/config/configDropins/defaults/liberty-stack-mpHealth.xml
+++ b/stackimage/config/configDropins/defaults/liberty-stack-mpHealth.xml
@@ -1,0 +1,5 @@
+<server>
+    <featureManager>
+        <feature>mpHealth-2.2</feature>
+    </featureManager>
+</server>

--- a/templates/devfile.yaml
+++ b/templates/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.0.0
 metadata:
   name: java-openliberty
-  version: 0.4.0-rc
+  version: 0.4.0-rc.1
   description: Java application stack using Open Liberty runtime
   alpha.build-dockerfile: "{{.DEVFILE_DOCKERFILE_LOC}}"
   alpha.deployment-manifest: "{{.DEVFILE_DEPLOY_YAML_LOC}}"

--- a/templates/outer-loop/Dockerfile
+++ b/templates/outer-loop/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /work/outer-loop-app && \
     rm -f src/main/liberty/config/configDropins/defaults/quick-start-security.xml && \
     mvn -e liberty:create package
 
-# process any resources or shared libraries - if they are present in the dependencies block for this project (there may be none potentially)
+# Process any resources or shared libraries - if they are present in the dependencies block for this project (there may be none potentially)
 # test to see if each is present and move to a well known location for later processing in the next stage
 # 
 RUN cd /work/outer-loop-app/target/liberty/wlp/usr/servers && \
@@ -30,17 +30,29 @@ RUN cd /work/outer-loop-app/target/liberty/wlp/usr/servers && \
 # Step 2: Package Open Liberty image
 FROM {{.OL_UBI_IMAGE}}
 
-#2a) copy any resources 
+# 2a) Copy user defined shared resources 
 COPY --from=compile --chown=1001:0 /work/shared /opt/ol/wlp/usr/shared/
 
-# 2b) next copy shared library
+# 2b) Copy user defined shared libraries
 #      but can't assume config/lib exists - copy from previous stage to a tmp holding place and test
 COPY --from=compile --chown=1001:0 /work/configlibdir/ /config
 
-# 2c) Server config, bootstrap.properties, and everything else
+# 2c) Copy user defined server config, bootstrap.properties, etc.
 COPY --from=compile --chown=1001:0 /work/config/ /config/
 
-# 2d) Changes to the application binary
+# 2d) Install the required features based on the defined configuration. This enables Liberty features and image size to be fit-for-purpose using featureUtility.
+RUN features.sh
+
+# 2e) Add the microprofile health feature configuration if it is not already defined in the user's configuration.
+RUN mkdir -p /tmp/stack/config/configDropins/defaults
+COPY --from=compile --chown=1001:0 /stack/ol/config/configDropins/defaults/ /tmp/stack/config/configDropins/defaults/
+RUN if ! /opt/ol/wlp/bin/productInfo featureInfo | grep -q mpHealth-[0-9]*.[0-9]*; then \
+        cp /tmp/stack/config/configDropins/defaults/liberty-stack-mpHealth.xml /config/configDropins/defaults; \
+        features.sh; \
+    fi
+RUN rm -rf /tmp/stack
+
+# 2f) Copy the application binary
 COPY --from=compile --chown=1001:0 /work/outer-loop-app/target/*.[ew]ar /config/apps
 RUN configure.sh && \
     chmod 664 /opt/ol/wlp/usr/servers/*/configDropins/defaults/keystore.xml

--- a/templates/stackimage/Dockerfile
+++ b/templates/stackimage/Dockerfile
@@ -30,6 +30,7 @@ RUN umask -S u=rwx,g=rwx,o=rx; mkdir -p /mvn/repository \
   && chown -R java_user /mvn \
   && chmod 775 /mvn \
   && mkdir -p /stacks/java-openliberty/priming-app \
+  && mkdir -p /stacks/java-openliberty/config \
   && chown -R java_user /stacks \
   && mkdir -p /output \
   && chown -R java_user /output \
@@ -39,6 +40,7 @@ COPY ./LICENSE /licenses/
 
 USER java_user
 
+ADD ./config /stacks/java-openliberty/config
 ADD ./priming-app/src /stacks/java-openliberty/priming-app/src
 COPY --chown=1001:0 ./priming-app/pom.xml /stacks/java-openliberty/priming-app/
 
@@ -94,11 +96,15 @@ RUN mkdir -p /output \
   && chmod 775 /opt/ol \
   && mkdir -p /work/outer-loop-app \
   && chown -R java_user /work \
-  && chmod -R 775 /work
+  && chmod -R 775 /work \
+  && mkdir -p /stack/ol/config/configDropins/defaults \
+  && chmod -R 775 /stack/ol/config/configDropins/defaults
+
 # Point to local /mvn/repository within container
 COPY --chown=1001:0 ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
 COPY --chown=1001:0 --from=builder /mvn /mvn
 
+COPY --chown=1001:0 --from=builder /stacks/java-openliberty/config/configDropins/defaults/ /stack/ol/config/configDropins/defaults/
 COPY --chown=1001:0 --from=builder /stacks/java-openliberty/priming-app/target/liberty /opt/ol
 COPY --chown=1001:0 ./LICENSE /licenses/
 


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Fixes #31 