### PR TITLE
Base ubi JDK with openJ9 image workaround

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 #
 # Base image used to build stack image
 #
-BASE_OS_IMAGE="${BASE_OS_IMAGE:-adoptopenjdk/openjdk11-openj9:ubi}"
+BASE_OS_IMAGE="${BASE_OS_IMAGE:-adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-ubi}"
 
 #
 # Version of Open Liberty runtime to use within both inner and outer loops


### PR DESCRIPTION
This PR works around adoptopenjdk/openjdk11-openj9:ubi arch: amd64 image missing from docker hub.
This is a temporary change until the churn around the openj9 0.27.1 version update for arch: amd64 takes place.