### PR TITLE
Update OL maven/gradle plugin versions

### DIFF
--- a/stackimage/priming-app/build.gradle
+++ b/stackimage/priming-app/build.gradle
@@ -41,7 +41,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.2'
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.2.1'
     }
 }
 

--- a/stackimage/priming-app/pom.xml
+++ b/stackimage/priming-app/pom.xml
@@ -27,7 +27,7 @@
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-surefire-plugin>3.0.0-M1</version.maven-surefire-plugin>
         <version.maven-failsafe-plugin>3.0.0-M1</version.maven-failsafe-plugin>
-        <version.liberty-maven-plugin>3.3.4</version.liberty-maven-plugin>
+        <version.liberty-maven-plugin>3.4</version.liberty-maven-plugin>
         <eclipse-microprofile-version>4.0.1</eclipse-microprofile-version>
         <jakarta-jakartaee-api-version>8.0.0</jakarta-jakartaee-api-version>
         <liberty.bootstrap.project.name>${project.artifactId}</liberty.bootstrap.project.name>


### PR DESCRIPTION
This PR updates the cached Open Liberty Maven plugin version to 3.4 and the Open Liberty Gradle plugin version to 3.2.1