### PR TITLE
Update Semeru jdk Image tag

### DIFF
--- a/build-ol.env
+++ b/build-ol.env
@@ -18,8 +18,7 @@ STACK_SHORT_NAME="openliberty"
 #
 # Base image used to build stack image
 #
-# THE USE OF ibmsemeruruntime/open-11-jdk:ubi-jdk-latest (JAVA_VERSION=jdk-11.0.12+7_openj9-0.27.0) IS A TEMPORARY WORKAROUND because Semeru Docker images are still a work in progress.
-BASE_OS_IMAGE="${BASE_OS_IMAGE:-ibmsemeruruntime/open-11-jdk:ubi-jdk-latest}"
+BASE_OS_IMAGE="${BASE_OS_IMAGE:-ibmsemeruruntime/open-11-jdk:ubi-jdk}"
 
 #
 # Version of Open Liberty runtime to install in the stack image

--- a/build-wl.env
+++ b/build-wl.env
@@ -18,8 +18,7 @@ STACK_SHORT_NAME="websphereliberty"
 #
 # Base image used to build stack image
 #
-# THE USE OF ibmsemeruruntime/open-11-jdk:ubi-jdk-latest (JAVA_VERSION=jdk-11.0.12+7_openj9-0.27.0) IS A TEMPORARY WORKAROUND because Semeru Docker images are still a work in progress.
-BASE_OS_IMAGE="${BASE_OS_IMAGE:-ibmsemeruruntime/open-11-jdk:ubi-jdk-latest}"
+BASE_OS_IMAGE="${BASE_OS_IMAGE:-ibmsemeruruntime/open-11-jdk:ubi-jdk}"
 
 #
 # Version of Open Liberty runtime to install in the stack image

--- a/stackimage/README.md
+++ b/stackimage/README.md
@@ -22,7 +22,7 @@ You can run build.sh with the target customization values as inputs or you can u
 
 ```
 source build-ol.env
-BASE_OS_IMAGE=ibmsemeruruntime/open-11-jdk:ubi-jdk-latest \
+BASE_OS_IMAGE=ibmsemeruruntime/open-11-jdk:ubi-jdk \
 LIBERTY_RUNTIME_VERSION=21.0.0.9 \
 STACK_IMAGE_MAVEN=<my-repo>/<image-maven>:<tag> \
 STACK_IMAGE_GRADLE=<my-repo>/<image-gradle>:<tag> \
@@ -36,7 +36,7 @@ vi build-ol.env
 ```
 ```
 ...
-BASE_OS_IMAGE="ibmsemeruruntime/open-11-jdk:ubi-jdk-latest"
+BASE_OS_IMAGE="ibmsemeruruntime/open-11-jdk:ubi-jdk"
 LIBERTY_RUNTIME_VERSION="21.0.0.9"
 STACK_IMAGE_MAVEN="<my-repo>/<image-maven>:<tag>"
 STACK_IMAGE_GRADLE="<my-repo>/<image-gradle>:<tag>"


### PR DESCRIPTION
Building the stack image fails because the Semeru JDK image currently being used: ibmsemeruruntime/open-11-jdk:ubi-jdk-latest no longer exists. 

This PR changes the Semeru image used to: ibmsemeruruntime/open-11-jdk:ubi-jdk